### PR TITLE
first commit

### DIFF
--- a/shimmer_ssd/modules/domains/attribute.py
+++ b/shimmer_ssd/modules/domains/attribute.py
@@ -314,6 +314,7 @@ class AttributeWithUnpairedDomainModule(DomainModule):
         )
 
 
+
 class AttributeLegacyDomainModule(DomainModule):
     latent_dim = 11
 
@@ -324,11 +325,17 @@ class AttributeLegacyDomainModule(DomainModule):
     def compute_loss(
         self, pred: torch.Tensor, target: torch.Tensor, raw_target: Any
     ) -> LossOutput:
-        pred_cat, pred_attr, _ = self.decode(pred)
-        target_cat, target_attr, _ = self.decode(target)
+        # print("pred", pred) 
+        # print("target", target)
+        pred_cat, pred_attr = self.decode(pred)
+        target_cat, target_attr = self.decode(target)
+        # print("pred_cat", pred_cat)
+        # print("pred_attr", pred_attr)
+        # print("target_cat", target_cat)
+        # # print("target_attr", target_attr)
 
         loss_attr = F.mse_loss(pred_attr, target_attr, reduction="mean")
-        loss_cat = F.nll_loss(pred_cat, torch.argmax(target_cat, 1))
+        loss_cat = F.cross_entropy(pred_cat, torch.argmax(target_cat, 1))
         loss = loss_attr + loss_cat
 
         return LossOutput(loss, metrics={"loss_attr": loss_attr, "loss_cat": loss_cat})
@@ -344,3 +351,7 @@ class AttributeLegacyDomainModule(DomainModule):
 
     def forward(self, x: Sequence[torch.Tensor]) -> list[torch.Tensor]:  # type: ignore
         return self.decode(self.encode(x))
+
+
+
+

--- a/shimmer_ssd/modules/domains/pretrained.py
+++ b/shimmer_ssd/modules/domains/pretrained.py
@@ -2,6 +2,8 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 
 from shimmer import DomainModule, GWDecoder, GWEncoder
+from shimmer.modules.gw_module import GWDecoder_legacy
+
 from torch.nn import Linear, Module
 
 from shimmer_ssd import PROJECT_DIR
@@ -149,12 +151,22 @@ def load_pretrained_domain(
         gw_encoder = Linear(module.latent_dim, workspace_dim, bias=bias)
         gw_decoder = Linear(workspace_dim, module.latent_dim, bias=bias)
     else:
-        gw_encoder = GWEncoder(
-            module.latent_dim, encoder_hidden_dim, workspace_dim, encoder_n_layers
-        )
-        gw_decoder = GWDecoder(
-            workspace_dim, decoder_hidden_dim, module.latent_dim, decoder_n_layers
-        )
+        match domain.domain_type:
+            case DomainModuleVariant.attr_legacy:
+                gw_encoder = GWEncoder(
+                    module.latent_dim, encoder_hidden_dim, workspace_dim, encoder_n_layers
+                )
+                gw_decoder = GWDecoder_legacy(
+                    workspace_dim, decoder_hidden_dim, module.latent_dim, decoder_n_layers
+                )
+            
+            case _:
+                gw_encoder = GWEncoder(
+                    module.latent_dim, encoder_hidden_dim, workspace_dim, encoder_n_layers
+                )
+                gw_decoder = GWDecoder(
+                    workspace_dim, decoder_hidden_dim, module.latent_dim, decoder_n_layers
+                )
 
     return module, gw_encoder, gw_decoder
 


### PR DESCRIPTION
handle the legacy case better, mainly by creating a special decoder in shimmer, adapting load_pretrained in pretrained.py and adapting the loss to cross entropy in AttributeLegacyDomainModule